### PR TITLE
adding hash to the subscription object

### DIFF
--- a/HISTORY.MD
+++ b/HISTORY.MD
@@ -1,3 +1,7 @@
+0.4.2 /2020-03-15
+=================
+* Updated code to avoid duplicated subscriptions by adding a hash to subscription object
+
 0.4.2 / 2020-02-16
 ==================
 

--- a/logic/observer.js
+++ b/logic/observer.js
@@ -1,4 +1,5 @@
-const errors = require('../util/errors'),
+    const crypto = require ('crypto')
+    const errors = require('../util/errors'),
     TransactionWatcher = require('./transaction-watcher'),
     Notifier = require('./notifier'),
     storage = require('./storage'),
@@ -38,10 +39,21 @@ class Observer {
     }
 
     subscribe(subscriptionParams, user) {
-        //TODO: prevent duplicate subscriptions by checking subscription hash (fields "account", "asset_type" etc.)
-        //https://www.npmjs.com/package/farmhash
         return this.loadSubscriptions()
             .then(() => {
+                // Create hash in the subscription to avoid duplication
+    
+                let hashData = `${subscriptionParams.account} ${subscriptionParams.asset_type} ${subscriptionParams.asset_code} ${subscriptionParams.asset_issuer}`
+                let hash = crypto.createHash('md5').update(hashData).digest("hex");
+                subscriptionParams.hash = hash
+
+                let subscription = this.subscriptions.find(s => s.hash == hash)
+
+                if(subscription){
+
+                    return subscription
+                }
+
                 if (this.getActiveSubscriptionsCount() >= config.maxActiveSubscriptions) {
                     return Promise.reject(errors.forbidden('Max active subscriptions exceeded.'))
                 }

--- a/logic/storage.js
+++ b/logic/storage.js
@@ -59,6 +59,19 @@ class Storage {
     }
 
     /**
+     * 
+     * @param {*} hash - the hash of the subscription
+     */
+
+    async fetchSubscriptioHash(hash){
+        this.provider.fetchSubscriptioHash(hash)
+        .then(subscription =>{
+            return subscription
+        }) 
+    } 
+
+
+    /**
      * Load next notification from db
      * @param {*} subscriptionId - subscription id
      * @returns {Promise<Notification>}
@@ -207,6 +220,8 @@ class Storage {
 
             subscription.expires = expirationDate
         }
+
+        subscription.hash = subscriptionParams.hash
 
         return this.provider.saveSubscription(subscription)
     }

--- a/models/subscription-model.js
+++ b/models/subscription-model.js
@@ -67,6 +67,12 @@ class SubscriptionModel extends Model {
      * Cached notifications, associated with the subscription
      */
     notifications
+
+    /**
+     * Subscription hash to avoid duplicated subscriptions
+     */
+    hash
+
 }
 
 module.exports = SubscriptionModel

--- a/persistence-layer/mongodb-storage-provider/index.js
+++ b/persistence-layer/mongodb-storage-provider/index.js
@@ -41,6 +41,10 @@ class MongoDBStorageProvider extends StorageProvider {
         return Subscription.findById(id)
     }
 
+    fetchSubscriptioHash(hash){
+        return Subscription.findOne({hash})
+    }
+
     fetchNextNotification(subscriptionId) {
         return Notification.findOne({subscriptions: toObjectId(subscriptionId)})
     }

--- a/persistence-layer/mongodb-storage-provider/models/subscription-db-model.js
+++ b/persistence-layer/mongodb-storage-provider/models/subscription-db-model.js
@@ -13,7 +13,8 @@ const subscriptionSchema = new Schema({
     reaction_url: {type: String},
     delivery_failures: {type: Number, default: 0},
     sent: {type: Number, default: 0},
-    expires: {type: Date}
+    expires: {type: Date},
+    hash:{type:String}
 },
 {
     timestamps: {createdAt: 'created', updatedAt: 'updated'}


### PR DESCRIPTION
Avoid duplications when trying to subscribe a Stellar account that was already saved. This is done by adding a hash to the subscription object based on the following transaction information:

1. Stellar accountId
2.  asset type
3.  asset code
4. asset issuer

In case the subscription was previously available in db. It is returned back to the client
