### PR TITLE
adding fee_charged and max_fee fields from tx to stream procesor

### DIFF
--- a/HISTORY.MD
+++ b/HISTORY.MD
@@ -1,3 +1,8 @@
+0.4.4 / 2020-03-16
+==================
+
+* Adding fee_charged and max_fee fields to the stream procesor
+
 0.4.2 / 2020-02-16
 ==================
 

--- a/logic/stream-processor.js
+++ b/logic/stream-processor.js
@@ -198,6 +198,8 @@ function parseTransaction(transaction) {
     const txDetails = {
         hash: transaction.hash,
         fee: xdrTx.fee,
+        fee_charged:transaction.fee_charged,
+        max_fee:transaction.max_fee,
         source: xdrTx.source,
         paging_token: transaction.paging_token,
         source_account_sequence: transaction.source_account_sequence,


### PR DESCRIPTION
Sometimes it is handy to know the actual fee paid by the user during surge pricing. Adding these two fields to the stream procesor