### PR TITLE
adding fee_charged and max_fee fields from tx to stream procesor

### DIFF
--- a/HISTORY.MD
+++ b/HISTORY.MD
@@ -1,3 +1,8 @@
+0.4.4 / 2020-03-16
+==================
+
+* Adding fee_charged and max_fee fields to the stream procesor
+
 0.4.2 / 2020-02-16
 ==================
 

--- a/HISTORY.MD
+++ b/HISTORY.MD
@@ -1,4 +1,4 @@
-0.4.4 / 2020-03-16
+0.4.3 / 2020-03-17
 ==================
 
 * Adding fee_charged and max_fee fields to the stream procesor

--- a/logic/stream-processor.js
+++ b/logic/stream-processor.js
@@ -198,6 +198,8 @@ function parseTransaction(transaction) {
     const txDetails = {
         hash: transaction.hash,
         fee: xdrTx.fee,
+        fee_charged:transaction.fee_charged,
+        max_fee:transaction.max_fee,
         source: xdrTx.source,
         paging_token: transaction.paging_token,
         source_account_sequence: transaction.source_account_sequence,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@stellar-expert/operations-notifier",
   "license": "MIT",
   "private": true,
-  "version": "0.4.2",
+  "version": "0.4.3",
   "author": "orbitlens<orbit.lens@stellar.expert>",
   "description": "Stellar operations observer and notifier.",
   "main": "app.js",


### PR DESCRIPTION
Sometimes it is handy to know the actual fee paid by the user during surge pricing. Adding these two fields to the stream procesor